### PR TITLE
feat: adaptations for leanprover/lean4#3159

### DIFF
--- a/ProofWidgets/Compat.lean
+++ b/ProofWidgets/Compat.lean
@@ -17,7 +17,7 @@ def ExprWithCtx.runMetaM (e : ExprWithCtx) (x : Expr → MetaM α) : IO α :=
 
 def ExprWithCtx.save (e : Expr) : MetaM ExprWithCtx :=
   return {
-    ci := ← ContextInfo.save
+    ci := { ← CommandContextInfo.save with }
     lctx := ← getLCtx
     expr := e
   }

--- a/ProofWidgets/Compat.lean
+++ b/ProofWidgets/Compat.lean
@@ -17,7 +17,7 @@ def ExprWithCtx.runMetaM (e : ExprWithCtx) (x : Expr → MetaM α) : IO α :=
 
 def ExprWithCtx.save (e : Expr) : MetaM ExprWithCtx :=
   return {
-    ci := ← CommandContextInfo.save
+    ci := ← ContextInfo.save
     lctx := ← getLCtx
     expr := e
   }

--- a/ProofWidgets/Compat.lean
+++ b/ProofWidgets/Compat.lean
@@ -17,7 +17,7 @@ def ExprWithCtx.runMetaM (e : ExprWithCtx) (x : Expr → MetaM α) : IO α :=
 
 def ExprWithCtx.save (e : Expr) : MetaM ExprWithCtx :=
   return {
-    ci := ← ContextInfo.save
+    ci := ← CommandContextInfo.save
     lctx := ← getLCtx
     expr := e
   }

--- a/ProofWidgets/Demos/LazyComputation.lean
+++ b/ProofWidgets/Demos/LazyComputation.lean
@@ -50,7 +50,7 @@ syntax (name := makeRunnerTac) "make_runner" : tactic
     -- Store the continuation and monad context.
     let props : RunnerWidgetProps := {
       k := ⟨{
-        ci := (← ContextInfo.save)
+        ci := { ← CommandContextInfo.save with }
         lctx := (← getLCtx)
         k := x
       }⟩}

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4-pr-releases:pr-release-3159
+leanprover/lean4:nightly-2024-01-23

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.5.0-rc1
+leanprover/lean4-pr-releases:pr-release-3159


### PR DESCRIPTION
This is the adaptations for leanprover/lean4#3159, which has landed in the nightly-2024-01-23 nightly release.

I have made a pre-release under the tag v0.0.27-pre. 

We won't be ready to merge this until `v4.6.0-rc1` is out.