### PR TITLE
feat: add background color to penrose display

### DIFF
--- a/widget/src/penroseDisplay.tsx
+++ b/widget/src/penroseDisplay.tsx
@@ -44,6 +44,7 @@ export default function(props: DiagramData & {pos: DocumentPosition}): JSX.Eleme
         )
 
     const colForeground = getCssColour('--vscode-editor-foreground')
+    const colBackground = getCssColour('--vscode-editor-background')
     const colTooltipBackground = getCssColour('--vscode-editorHoverWidget-background')
     const colTooltipForeground = getCssColour('--vscode-editorHoverWidget-foreground')
     const colTooltipBorder = getCssColour('--vscode-editorHoverWidget-border')
@@ -52,6 +53,7 @@ export default function(props: DiagramData & {pos: DocumentPosition}): JSX.Eleme
 `
 theme {
     color foreground = ${colForeground}
+    color background = ${colBackground}
     color tooltipBackground = ${colTooltipBackground}
     color tooltipForeground = ${colTooltipForeground}
     color tooltipBorder = ${colTooltipBorder}


### PR DESCRIPTION
I'd like to use this feature in https://github.com/leanprover-community/mathlib4/pull/10581.