### PR TITLE
feat: filterDetails component used in library rewrite

### DIFF
--- a/ProofWidgets.lean
+++ b/ProofWidgets.lean
@@ -1,5 +1,6 @@
 import ProofWidgets.Compat
 import ProofWidgets.Component.Basic
+import ProofWidgets.Component.FilterDetails
 import ProofWidgets.Component.HtmlDisplay
 import ProofWidgets.Component.InteractiveSvg
 import ProofWidgets.Component.MakeEditLink

--- a/ProofWidgets/Component/FilterDetails.lean
+++ b/ProofWidgets/Component/FilterDetails.lean
@@ -4,8 +4,8 @@ open Lean ProofWidgets
 
 /-- The props for the `FilterDetails` component. -/
 structure FilterDetailsProps where
-  /-- The title -/
-  message : String
+  /-- Contents of the `<summary>` -/
+  summary : Html
   /-- What is shown in the filtered state -/
   filtered : Html
   /-- What is shown in the non-filtered state -/
@@ -14,8 +14,9 @@ structure FilterDetailsProps where
   initiallyFiltered : Bool
 deriving Server.RpcEncodable
 
-/-- the `FilterDetails` component is like a details Html element, but it also has a filter button
-that allows you to switch between a filtered and unfiltered state -/
+/-- The `FilterDetails` component is like a `<details>` HTML element,
+but also has a filter button
+that allows you to switch between filtered and unfiltered states. -/
 @[widget_module]
 def FilterDetails : Component FilterDetailsProps where
   javascript := include_str ".." /  ".." / ".lake" / "build" / "js" / "FilterDetails.js"

--- a/ProofWidgets/Component/FilterDetails.lean
+++ b/ProofWidgets/Component/FilterDetails.lean
@@ -2,21 +2,21 @@ import ProofWidgets.Data.Html
 
 open Lean ProofWidgets
 
-/-- The props for the `FilterDetails` component. -/
+/-- Props for the `FilterDetails` component. -/
 structure FilterDetailsProps where
-  /-- Contents of the `<summary>` -/
+  /-- Contents of the `<summary>`. -/
   summary : Html
-  /-- What is shown in the filtered state -/
+  /-- What is shown in the filtered state. -/
   filtered : Html
-  /-- What is shown in the non-filtered state -/
+  /-- What is shown in the non-filtered state. -/
   all : Html
-  /-- Whether to start in the filtered state -/
-  initiallyFiltered : Bool
-deriving Server.RpcEncodable
+  /-- Whether to start in the filtered state. -/
+  initiallyFiltered : Bool := true
+  deriving Server.RpcEncodable
 
 /-- The `FilterDetails` component is like a `<details>` HTML element,
 but also has a filter button
 that allows you to switch between filtered and unfiltered states. -/
 @[widget_module]
 def FilterDetails : Component FilterDetailsProps where
-  javascript := include_str ".." /  ".." / ".lake" / "build" / "js" / "FilterDetails.js"
+  javascript := include_str ".." /  ".." / ".lake" / "build" / "js" / "filterDetails.js"

--- a/ProofWidgets/Component/FilterDetails.lean
+++ b/ProofWidgets/Component/FilterDetails.lean
@@ -1,0 +1,21 @@
+import ProofWidgets.Data.Html
+
+open Lean ProofWidgets
+
+/-- The props for the `FilterDetails` component. -/
+structure FilterDetailsProps where
+  /-- The title -/
+  message : String
+  /-- What is shown in the filtered state -/
+  filtered : Html
+  /-- What is shown in the non-filtered state -/
+  all : Html
+  /-- Whether to start in the filtered state -/
+  initiallyFiltered : Bool
+deriving Server.RpcEncodable
+
+/-- the `FilterDetails` component is like a details Html element, but it also has a filter button
+that allows you to switch between a filtered and unfiltered state -/
+@[widget_module]
+def FilterDetails : Component FilterDetailsProps where
+  javascript := include_str ".." /  ".." / ".lake" / "build" / "js" / "FilterDetails.js"

--- a/widget/src/filterDetails.tsx
+++ b/widget/src/filterDetails.tsx
@@ -4,7 +4,7 @@ import { DocumentPosition } from '@leanprover/infoview/*';
 
 interface FilterDetailsProps {
     pos : DocumentPosition
-    message : string
+    summary : Html
     filtered : Html
     all : Html
     initiallyFiltered : boolean
@@ -15,7 +15,7 @@ export default function FilterDetails(props: FilterDetailsProps) {
 
     return <details open>
         <summary className="mv2 pointer">
-            {props.message}
+            <HtmlDisplay pos={props.pos} html={props.summary} />
             <span className="fr" onClick={e => { e.preventDefault() }}>
                 <a className="link pointer mh2 dim codicon codicon-filter" title="filter"
                     onClick={_ => { setFiltered(s => !s) }} />

--- a/widget/src/filterDetails.tsx
+++ b/widget/src/filterDetails.tsx
@@ -17,7 +17,9 @@ export default function FilterDetails(props: FilterDetailsProps) {
         <summary className="mv2 pointer">
             <HtmlDisplay pos={props.pos} html={props.summary} />
             <span className="fr" onClick={e => { e.preventDefault() }}>
-                <a className="link pointer mh2 dim codicon codicon-filter" title="filter"
+                <a className={"link pointer mh2 dim codicon " +
+                    (isFiltered ? "codicon-filter-filled " : "codicon-filter ")}
+                    title="Show fewer contents"
                     onClick={_ => { setFiltered(s => !s) }} />
             </span>
         </summary>

--- a/widget/src/filterDetails.tsx
+++ b/widget/src/filterDetails.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import HtmlDisplay, { Html } from './htmlDisplay';
+import { DocumentPosition } from '@leanprover/infoview/*';
+
+interface FilterDetailsProps {
+    pos : DocumentPosition
+    message : string
+    filtered : Html
+    all : Html
+    initiallyFiltered : boolean
+}
+
+export default function FilterDetails(props: FilterDetailsProps) {
+    const [isFiltered, setFiltered] = React.useState(props.initiallyFiltered);
+
+    return <details open>
+        <summary className="mv2 pointer">
+            {props.message}
+            <span className="fr" onClick={e => { e.preventDefault() }}>
+                <a className="link pointer mh2 dim codicon codicon-filter" title="filter"
+                    onClick={_ => { setFiltered(s => !s) }} />
+            </span>
+        </summary>
+        <HtmlDisplay pos={props.pos} html={isFiltered ? props.filtered : props.all}/>
+    </details>
+}


### PR DESCRIPTION
This is the bit of TypeScript that I need for my `rw??` tactic. It is a details html tag, with an additional filter button that allows you to switch between two states of what is shown in the details.

I think the field `initiallyFiltered` in `FilterDetailsProps` is probably redundant and should always be set to `true`.