### PR TITLE
chore: change the syntax node name to match the parser

### DIFF
--- a/ProofWidgets/Demos/Jsx.lean
+++ b/ProofWidgets/Demos/Jsx.lean
@@ -11,5 +11,6 @@ theorem ghjk : True := by
   -- Put your cursor over any of the `html!` lines
   html! <b>What, HTML in Lean?! </b>
   html! <i>And another!</i>
-  html! <img src="https://upload.wikimedia.org/wikipedia/commons/a/a5/Parrot_montage.jpg"/>
+  -- attributes and text nodes can be interpolated
+  html! <img src={ "https://" ++ "upload.wikimedia.org/wikipedia/commons/a/a5/Parrot_montage.jpg"} alt="parrots" />
   trivial


### PR DESCRIPTION
Previously the node was called `jsxText` but the parser was called `ProofWidgets.Jsx.jsxText`. This changes the former to match the latter.

Also adds a docstring to `{}`-interpolation, which appears in VSCode hovers.