### PR TITLE
fix: improve the delaborators for `ProofWidgets.Html`

### DIFF
--- a/ProofWidgets/Data/Html.lean
+++ b/ProofWidgets/Data/Html.lean
@@ -134,8 +134,6 @@ partial def delabArrayLiteral {α} (elem : DelabM α) : DelabM (Array α) := do
   | List.toArray _ _ => List.toArray <$> (withNaryArg 1 <| delabListLiteral elem)
   | _ => failure
 
-#check annotateTermInfo
-
 /-- A copy of `Delaborator.annotateTermLikeInfo` for other categories. -/
 def annotateTermLikeInfo (stx : TSyntax n) : DelabM (TSyntax n) := do
   let stx ← annotateCurPos ⟨stx⟩

--- a/ProofWidgets/Data/Html.lean
+++ b/ProofWidgets/Data/Html.lean
@@ -128,19 +128,19 @@ partial def delabListLiteral {α} (elem : DelabM α) : DelabM (List α) := do
   | _ => failure
 
 
-/-- Delaborate the elements of a list literal separately, calling `elem` on each. -/
+/-- Delaborate the elements of an array literal separately, calling `elem` on each. -/
 partial def delabArrayLiteral {α} (elem : DelabM α) : DelabM (Array α) := do
   match_expr ← getExpr with
   | List.toArray _ _ => List.toArray <$> (withNaryArg 1 <| delabListLiteral elem)
   | _ => failure
 
-/-- A copy of `Delaborator.annotateTermLikeInfo` for other categories. -/
+/-- A copy of `Delaborator.annotateTermInfo` for other syntactic categories. -/
 def annotateTermLikeInfo (stx : TSyntax n) : DelabM (TSyntax n) := do
   let stx ← annotateCurPos ⟨stx⟩
   addTermInfo (← getPos) stx (← getExpr)
   pure ⟨stx⟩
 
-/-- A copy of `Delaborator.withAnnotateTermLikeInfo` for other categories. -/
+/-- A copy of `Delaborator.withAnnotateTermInfo` for other syntactic categories. -/
 def withAnnotateTermLikeInfo (d : DelabM (TSyntax n)) : DelabM (TSyntax n) := do
   let stx ← d
   annotateTermLikeInfo stx

--- a/ProofWidgets/Demos/Jsx.lean
+++ b/ProofWidgets/Demos/Jsx.lean
@@ -21,7 +21,7 @@ section delaborator_tests
 #print x
 
 /-- info: <span id={Lean.Json.str "greeting"}>Hello world</span> : ProofWidgets.Html -/
-#guard_msgs in
+-- #guard_msgs in
 #check <span id="greeting">Hello world</span>
 
 /-- info: <span>Hello interpolated world</span> : ProofWidgets.Html -/

--- a/ProofWidgets/Demos/Jsx.lean
+++ b/ProofWidgets/Demos/Jsx.lean
@@ -2,7 +2,7 @@ import ProofWidgets.Component.HtmlDisplay
 
 open scoped ProofWidgets.Jsx -- ⟵ remember this!
 
-def x := <b>You can use HTML in lean! {.text <| toString <| 4 + 5} <hr/> </b>
+def x := <b «class»={1}>You can use HTML in lean! {.text <| toString <| 4 + 5} <hr/> </b>
 
 -- Put your cursor over this
 #html x
@@ -17,23 +17,45 @@ theorem ghjk : True := by
 
 section delaborator_tests
 
+open ProofWidgets.Html Lean
+
 -- interactive test: check that the hovers in the infoview on subexpressions are correct
 #print x
 
-/-- info: <span id={Lean.Json.str "greeting"}>Hello world</span> : ProofWidgets.Html -/
--- #guard_msgs in
+
+/-- info: <span id={Json.str "greeting"}>Hello world</span> : ProofWidgets.Html -/
+#guard_msgs in
 #check <span id="greeting">Hello world</span>
 
 /-- info: <span>Hello interpolated world</span> : ProofWidgets.Html -/
 #guard_msgs in
 #check <span>Hello {.text "interpolated"} world</span>
 
-/-- info: <span>Hello {ProofWidgets.Html.text "<>"}world</span> : ProofWidgets.Html -/
+/-- info: <span>Hello {text "<>"}world</span> : ProofWidgets.Html -/
 #guard_msgs in
 #check <span>Hello {.text "<>"} world</span>
 
 /-- info: <hr/> : ProofWidgets.Html -/
 #guard_msgs in
 #check <hr />
+
+structure CustomProps where
+  val : Nat
+  deriving Server.RpcEncodable
+
+def CustomComponent : ProofWidgets.Component CustomProps where
+  javascript := ""
+
+/-- info: <div><CustomComponent val={2}>Content</CustomComponent></div> : ProofWidgets.Html -/
+#guard_msgs in
+#check <div><CustomComponent val={2}>Content</CustomComponent></div>
+
+def ProdComponent : ProofWidgets.Component (Nat × Nat) where
+  javascript := ""
+
+-- TODO: fix this
+/-- info: <div>{ofComponent ProdComponent (1, 2) #[]}</div> : ProofWidgets.Html -/
+#guard_msgs in
+#check <div><ProdComponent fst={1} snd={2} /></div>
 
 end delaborator_tests

--- a/ProofWidgets/Demos/Jsx.lean
+++ b/ProofWidgets/Demos/Jsx.lean
@@ -14,3 +14,26 @@ theorem ghjk : True := by
   -- attributes and text nodes can be interpolated
   html! <img src={ "https://" ++ "upload.wikimedia.org/wikipedia/commons/a/a5/Parrot_montage.jpg"} alt="parrots" />
   trivial
+
+section delaborator_tests
+
+-- interactive test: check that the hovers in the infoview on subexpressions are correct
+#print x
+
+/-- info: <span id={Lean.Json.str "greeting"}>Hello world</span> : ProofWidgets.Html -/
+#guard_msgs in
+#check <span id="greeting">Hello world</span>
+
+/-- info: <span>Hello interpolated world</span> : ProofWidgets.Html -/
+#guard_msgs in
+#check <span>Hello {.text "interpolated"} world</span>
+
+/-- info: <span>Hello {ProofWidgets.Html.text "<>"}world</span> : ProofWidgets.Html -/
+#guard_msgs in
+#check <span>Hello {.text "<>"} world</span>
+
+/-- info: <hr/> : ProofWidgets.Html -/
+#guard_msgs in
+#check <hr />
+
+end delaborator_tests

--- a/ProofWidgets/Demos/Jsx.lean
+++ b/ProofWidgets/Demos/Jsx.lean
@@ -2,7 +2,7 @@ import ProofWidgets.Component.HtmlDisplay
 
 open scoped ProofWidgets.Jsx -- ⟵ remember this!
 
-def x := <b «class»={1}>You can use HTML in lean! {.text <| toString <| 4 + 5} <hr/> </b>
+def x := <b>You can use HTML in lean! {.text <| toString <| 4 + 5} <hr/> </b>
 
 -- Put your cursor over this
 #html x
@@ -14,48 +14,3 @@ theorem ghjk : True := by
   -- attributes and text nodes can be interpolated
   html! <img src={ "https://" ++ "upload.wikimedia.org/wikipedia/commons/a/a5/Parrot_montage.jpg"} alt="parrots" />
   trivial
-
-section delaborator_tests
-
-open ProofWidgets.Html Lean
-
--- interactive test: check that the hovers in the infoview on subexpressions are correct
-#print x
-
-
-/-- info: <span id={Json.str "greeting"}>Hello world</span> : ProofWidgets.Html -/
-#guard_msgs in
-#check <span id="greeting">Hello world</span>
-
-/-- info: <span>Hello interpolated world</span> : ProofWidgets.Html -/
-#guard_msgs in
-#check <span>Hello {.text "interpolated"} world</span>
-
-/-- info: <span>Hello {text "<>"}world</span> : ProofWidgets.Html -/
-#guard_msgs in
-#check <span>Hello {.text "<>"} world</span>
-
-/-- info: <hr/> : ProofWidgets.Html -/
-#guard_msgs in
-#check <hr />
-
-structure CustomProps where
-  val : Nat
-  deriving Server.RpcEncodable
-
-def CustomComponent : ProofWidgets.Component CustomProps where
-  javascript := ""
-
-/-- info: <div><CustomComponent val={2}>Content</CustomComponent></div> : ProofWidgets.Html -/
-#guard_msgs in
-#check <div><CustomComponent val={2}>Content</CustomComponent></div>
-
-def ProdComponent : ProofWidgets.Component (Nat × Nat) where
-  javascript := ""
-
--- TODO: fix this
-/-- info: <div>{ofComponent ProdComponent (1, 2) #[]}</div> : ProofWidgets.Html -/
-#guard_msgs in
-#check <div><ProdComponent fst={1} snd={2} /></div>
-
-end delaborator_tests

--- a/test/delab.lean
+++ b/test/delab.lean
@@ -1,0 +1,43 @@
+import ProofWidgets.Data.Html
+
+open scoped ProofWidgets.Jsx
+open ProofWidgets.Html Lean
+
+
+/-- info: <span id={Json.str "greeting"}>Hello world</span> : ProofWidgets.Html -/
+#guard_msgs in
+#check <span id="greeting">Hello world</span>
+
+/-- info: <span>Hello interpolated world</span> : ProofWidgets.Html -/
+#guard_msgs in
+#check <span>Hello {.text "interpolated"} world</span>
+
+/-- info: <span>Hello {text "<>"}world</span> : ProofWidgets.Html -/
+#guard_msgs in
+#check <span>Hello {.text "<>"} world</span>
+
+/-- info: <hr/> : ProofWidgets.Html -/
+#guard_msgs in
+#check <hr />
+
+structure CustomProps where
+  val : Nat
+  deriving Server.RpcEncodable
+
+def CustomComponent : ProofWidgets.Component CustomProps where
+  javascript := ""
+
+/-- info: <div><CustomComponent val={2}>Content</CustomComponent></div> : ProofWidgets.Html -/
+#guard_msgs in
+#check <div><CustomComponent val={2}>Content</CustomComponent></div>
+
+def ProdComponent : ProofWidgets.Component (Nat × Nat) where
+  javascript := ""
+
+-- TODO: fix this
+/-- info: <div>{ofComponent ProdComponent (1, 2) #[]}</div> : ProofWidgets.Html -/
+#guard_msgs in
+#check <div><ProdComponent fst={1} snd={2} /></div>
+
+-- interactive test: check that the hovers in the infoview on subexpressions are correct
+#check <span id="test">Hello {.text "<>"} world<CustomComponent val={2} /></span>

--- a/test/delab.lean
+++ b/test/delab.lean
@@ -4,7 +4,7 @@ open scoped ProofWidgets.Jsx
 open ProofWidgets.Html Lean
 
 
-/-- info: <span id={Json.str "greeting"}>Hello world</span> : ProofWidgets.Html -/
+/-- info: <span id="greeting">Hello world</span> : ProofWidgets.Html -/
 #guard_msgs in
 #check <span id="greeting">Hello world</span>
 
@@ -22,14 +22,16 @@ open ProofWidgets.Html Lean
 
 structure CustomProps where
   val : Nat
+  str : String
   deriving Server.RpcEncodable
 
 def CustomComponent : ProofWidgets.Component CustomProps where
   javascript := ""
 
-/-- info: <div><CustomComponent val={2}>Content</CustomComponent></div> : ProofWidgets.Html -/
+-- TODO: spacing between attributes
+/-- info: <div><CustomComponent val={2}str={"3"}>Content</CustomComponent></div> : ProofWidgets.Html -/
 #guard_msgs in
-#check <div><CustomComponent val={2}>Content</CustomComponent></div>
+#check <div><CustomComponent val={2} str="3">Content</CustomComponent></div>
 
 def ProdComponent : ProofWidgets.Component (Nat × Nat) where
   javascript := ""
@@ -40,4 +42,4 @@ def ProdComponent : ProofWidgets.Component (Nat × Nat) where
 #check <div><ProdComponent fst={1} snd={2} /></div>
 
 -- interactive test: check that the hovers in the infoview on subexpressions are correct
-#check <span id="test">Hello {.text "<>"} world<CustomComponent val={2} /></span>
+#check <span id="test">Hello {.text "<>"} world<CustomComponent val={2} str="3" /></span>


### PR DESCRIPTION
Previously:
```lean
import ProofWidgets.Data.Html
open scoped ProofWidgets.Jsx

#check <span id="greeting">Hello world {.text ("a" ++ "b")}</span>
```
gave
```jsx
<span id={Lean.Json.str
          "greeting"}>{ProofWidgets.Html.text
        "Hello world "}{ProofWidgets.Html.text ("a" ++ "b")}</span> : ProofWidgets.Html
```
now it gives
```jsx
<span id={Lean.Json.str "greeting"}>Hello world {ProofWidgets.Html.text ("a" ++ "b")}</span> : ProofWidgets.Html
```

Generally, I think implementing delaborators in terms of other delaborators is a bad idea; this works on the raw expressions instead.

This also adds a few more elaboration annotations to the pieces of the syntax; for instance, hovering over `id=` shows that the `id` came from the string `"id"` etc.