### PR TITLE
Adding functionality to render Latex as SVG.

### DIFF
--- a/ProofWidgets.lean
+++ b/ProofWidgets.lean
@@ -3,6 +3,7 @@ import ProofWidgets.Component.Basic
 import ProofWidgets.Component.FilterDetails
 import ProofWidgets.Component.HtmlDisplay
 import ProofWidgets.Component.InteractiveSvg
+import ProofWidgets.Component.Latex
 import ProofWidgets.Component.MakeEditLink
 import ProofWidgets.Component.OfRpcMethod
 import ProofWidgets.Component.Panel.Basic

--- a/ProofWidgets/Component/Latex.lean
+++ b/ProofWidgets/Component/Latex.lean
@@ -1,0 +1,17 @@
+import Lean.Server.Rpc.Basic
+
+import ProofWidgets.Component.Basic
+
+namespace ProofWidgets
+
+open Lean Server
+
+structure LatexProps where
+  content : String
+  deriving Server.RpcEncodable
+
+@[widget_module]
+def Latex : Component LatexProps where
+  javascript := include_str ".." / ".." / ".lake" / "build" / "js" / "latexToSvg.js"
+
+end ProofWidgets

--- a/ProofWidgets/Demos/ExprPresentation.lean
+++ b/ProofWidgets/Demos/ExprPresentation.lean
@@ -1,15 +1,15 @@
 import ProofWidgets.Component.Panel.SelectionPanel
 import ProofWidgets.Component.Panel.GoalTypePanel
 
-open ProofWidgets Jsx
+open ProofWidgets Jsx Lean Server
 
 structure LatexProps where
-  content : string
+  content : String
   deriving Server.RpcEncodable
 
 @[widget_module]
 def Latex : Component LatexProps where
-  javascript := include_str ".." / ".." / ".." / ".lake" / "build" / "js" / "latexToSvg.js"
+  javascript := include_str ".." / ".." / ".lake" / "build" / "js" / "latexToSvg.js"
 
 @[expr_presenter]
 def latex_presenter : ExprPresenter where
@@ -17,9 +17,17 @@ def latex_presenter : ExprPresenter where
   layoutKind := .inline
   present e :=
     return <span>
-        {.text "🐙 "}<Latex content={← Lean.Widget.ppExprTagged e} />{.text " 🐙"}
+        {.text "🐙 "}<Latex content={(← Lean.Meta.ppExpr e).pretty} />{.text " 🐙"}
       </span>
 
+@[expr_presenter]
+def latex_presenter2 : ExprPresenter where
+  userName := "Latex2"
+  layoutKind := .block
+  present e :=
+    return <span>
+        {.text "🐙 "}<Latex content="\\frac{1}{2}\\mbox{hello, we will prove that } \\begin{align}a sdfs&=&sdfsb\\\\c&d&i\\end{align}" />{.text " 🐙"}
+      </span>
 
 @[expr_presenter]
 def presenter : ExprPresenter where

--- a/ProofWidgets/Demos/ExprPresentation.lean
+++ b/ProofWidgets/Demos/ExprPresentation.lean
@@ -3,6 +3,24 @@ import ProofWidgets.Component.Panel.GoalTypePanel
 
 open ProofWidgets Jsx
 
+structure LatexProps where
+  content : string
+  deriving Server.RpcEncodable
+
+@[widget_module]
+def Latex : Component LatexProps where
+  javascript := include_str ".." / ".." / ".." / ".lake" / "build" / "js" / "latexToSvg.js"
+
+@[expr_presenter]
+def latex_presenter : ExprPresenter where
+  userName := "Latex"
+  layoutKind := .inline
+  present e :=
+    return <span>
+        {.text "🐙 "}<Latex content={← Lean.Widget.ppExprTagged e} />{.text " 🐙"}
+      </span>
+
+
 @[expr_presenter]
 def presenter : ExprPresenter where
   userName := "With octopodes"

--- a/ProofWidgets/Demos/ExprPresentation.lean
+++ b/ProofWidgets/Demos/ExprPresentation.lean
@@ -1,33 +1,7 @@
 import ProofWidgets.Component.Panel.SelectionPanel
 import ProofWidgets.Component.Panel.GoalTypePanel
 
-open ProofWidgets Jsx Lean Server
-
-structure LatexProps where
-  content : String
-  deriving Server.RpcEncodable
-
-@[widget_module]
-def Latex : Component LatexProps where
-  javascript := include_str ".." / ".." / ".lake" / "build" / "js" / "latexToSvg.js"
-
-@[expr_presenter]
-def latex_presenter : ExprPresenter where
-  userName := "Latex"
-  layoutKind := .inline
-  present e :=
-    return <span>
-        {.text "🐙 "}<Latex content={(← Lean.Meta.ppExpr e).pretty} />{.text " 🐙"}
-      </span>
-
-@[expr_presenter]
-def latex_presenter2 : ExprPresenter where
-  userName := "Latex2"
-  layoutKind := .block
-  present e :=
-    return <span>
-        {.text "🐙 "}<Latex content="\\frac{1}{2}\\mbox{hello, we will prove that } \\begin{align}a sdfs&=&sdfsb\\\\c&d&i\\end{align}" />{.text " 🐙"}
-      </span>
+open ProofWidgets Jsx
 
 @[expr_presenter]
 def presenter : ExprPresenter where

--- a/ProofWidgets/Demos/LatexExpr.lean
+++ b/ProofWidgets/Demos/LatexExpr.lean
@@ -1,9 +1,10 @@
 import ProofWidgets.Component.Panel.GoalTypePanel
+import ProofWidgets.Component.Panel.SelectionPanel  -- Needed for GoalTypePanel
 import ProofWidgets.Component.HtmlDisplay
 import ProofWidgets.Component.Latex
-import ProofWidgets.Presentation.Expr
+import ProofWidgets.Demos.Macro
 
-open ProofWidgets Jsx
+open ProofWidgets Jsx Lean
 
 @[expr_presenter]
 def latex_presenter : ExprPresenter where
@@ -21,8 +22,8 @@ example : 2 + 2 = 4 ∧ 3 + 3 = 6 := by
     rfl
     rfl
 
-macro "#latex " text: String : command =>
+macro "#latex " src:term : command =>
   Lean.TSyntax.mkInfoCanonical <$>
-    `(#html <Latex content={$text} />)
+    `(#html <Latex content={$src} />)
 
-#latex "\\mbox{This is Latex: }\\forall x \\in \\mathbb{N}, x\\ge 0,\, \\mbox{ rendered as SVG.}"
+#latex "\\mbox{This is a latex string: }\\forall x \\in \\mathbb{N}, x\\ge 0,\\, \\mbox{ rendered as SVG.}"

--- a/ProofWidgets/Demos/LatexExpr.lean
+++ b/ProofWidgets/Demos/LatexExpr.lean
@@ -1,0 +1,28 @@
+import ProofWidgets.Component.Panel.GoalTypePanel
+import ProofWidgets.Component.HtmlDisplay
+import ProofWidgets.Component.Latex
+import ProofWidgets.Presentation.Expr
+
+open ProofWidgets Jsx
+
+@[expr_presenter]
+def latex_presenter : ExprPresenter where
+  userName := "Latex"
+  layoutKind := .inline
+  present e :=
+    return <span>
+        <Latex content={(← Lean.Meta.ppExpr e).pretty} />
+      </span>
+
+example : 2 + 2 = 4 ∧ 3 + 3 = 6 := by
+  with_panel_widgets [GoalTypePanel]
+    -- Place cursor here.
+    constructor
+    rfl
+    rfl
+
+macro "#latex " text: String : command =>
+  Lean.TSyntax.mkInfoCanonical <$>
+    `(#html <Latex content={$text} />)
+
+#latex "\\mbox{This is Latex: }\\forall x \\in \\mathbb{N}, x\\ge 0,\, \\mbox{ rendered as SVG.}"

--- a/widget/src/exprPresentation.tsx
+++ b/widget/src/exprPresentation.tsx
@@ -6,7 +6,6 @@ import InteractiveExpr from './interactiveExpr'
 
 import { mathjax } from 'mathjax-full/js/mathjax'
 import { TeX } from 'mathjax-full/js/input/tex'
-import { CHTML } from 'mathjax-full/js/output/chtml'
 import { SVG } from 'mathjax-full/js/output/svg'
 import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages'
 import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor'
@@ -31,8 +30,7 @@ function get_mathjax_svg(math: string): string {
   return adaptor.outerHTML(node)
 }
 
-export function RenderLatex({content}: {content: string}): JSX.Element {
-  // For explanation of flow-root see https://stackoverflow.com/a/32301823
+export function RenderLatexSvg({content}: {content: string}): JSX.Element {
   return <div dangerouslySetInnerHTML={{ __html: get_mathjax_svg(content) }} />
 }
 

--- a/widget/src/exprPresentation.tsx
+++ b/widget/src/exprPresentation.tsx
@@ -33,7 +33,7 @@ function get_mathjax_svg(math: string): string {
 
 export function RenderLatex({content}: {content: string}): JSX.Element {
   // For explanation of flow-root see https://stackoverflow.com/a/32301823
-  return <div dangerouslySetInnerHTML={{ __html: get_mathjax_svg(content) }} />}</div>
+  return <div dangerouslySetInnerHTML={{ __html: get_mathjax_svg(content) }} />
 }
 
 type ExprWithCtx = RpcPtr<'ProofWidgets.ExprWithCtx'>

--- a/widget/src/exprPresentation.tsx
+++ b/widget/src/exprPresentation.tsx
@@ -4,6 +4,38 @@ import { RpcContext, RpcSessionAtPos, RpcPtr, Name, DocumentPosition, mapRpcErro
 import HtmlDisplay, { Html } from './htmlDisplay'
 import InteractiveExpr from './interactiveExpr'
 
+import { mathjax } from 'mathjax-full/js/mathjax'
+import { TeX } from 'mathjax-full/js/input/tex'
+import { CHTML } from 'mathjax-full/js/output/chtml'
+import { SVG } from 'mathjax-full/js/output/svg'
+import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages'
+import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor'
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html'
+
+const adaptor = liteAdaptor()
+RegisterHTMLHandler(adaptor)
+
+const mathjax_document = mathjax.document('', {
+  InputJax: new TeX({ packages: AllPackages }),
+  OutputJax: new SVG({ fontCache: 'local' })
+})
+
+const mathjax_options = {
+  em: 16,
+  ex: 8,
+  containerWidth: 1280
+}
+
+function get_mathjax_svg(math: string): string {
+  const node = mathjax_document.convert(math, mathjax_options)
+  return adaptor.outerHTML(node)
+}
+
+export function RenderLatex({content}: {content: string}): JSX.Element {
+  // For explanation of flow-root see https://stackoverflow.com/a/32301823
+  return <div dangerouslySetInnerHTML={{ __html: get_mathjax_svg(content) }} />}</div>
+}
+
 type ExprWithCtx = RpcPtr<'ProofWidgets.ExprWithCtx'>
 
 interface ExprPresentationData {

--- a/widget/src/latexToSvg.tsx
+++ b/widget/src/latexToSvg.tsx
@@ -1,5 +1,5 @@
-import { RenderLatex } from "./exprPresentation";
+import { RenderLatexSvg } from "./exprPresentation";
 
 export default function ({content}: {content: string}) {
-  return <RenderLatex content={content} />
+  return <RenderLatexSvg content={content} />
 }

--- a/widget/src/latexToSvg.tsx
+++ b/widget/src/latexToSvg.tsx
@@ -1,0 +1,5 @@
+import { RenderLatex } from "./exprPresentation";
+
+export default function ({content}: {content: string}) {
+  return <RenderLatex content=""/>
+}

--- a/widget/src/latexToSvg.tsx
+++ b/widget/src/latexToSvg.tsx
@@ -1,5 +1,5 @@
 import { RenderLatex } from "./exprPresentation";
 
 export default function ({content}: {content: string}) {
-  return <RenderLatex content=""/>
+  return <RenderLatex content={content} />
 }


### PR DESCRIPTION
This introduces a Jsx component <Latex content="..."/> which renders a latex string as SVG.
This can be used for example in an expression presenter to display a goal in Latex, or in an HTML display.
See Demos/LeanExpr.lean for usage examples.