### PR TITLE
Fix JSX example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import ProofWidgets.Component.HtmlDisplay
 open scoped ProofWidgets.Jsx
 
 -- click on the line below to see it in your infoview!
-#html <b>You can use HTML in lean! {.text s!"{1 + 2}"}</b>
+#html <b>You can use HTML in Lean {.text s!"{1 + 3}"}!</b>
 ```
 
 See the `Jsx.lean` and `ExprPresentation.lean` demos.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import ProofWidgets.Component.HtmlDisplay
 open scoped ProofWidgets.Jsx
 
 -- click on the line below to see it in your infoview!
-#html <b>You can use HTML in lean! {toString <| 1 + 2>}</b>
+#html <b>You can use HTML in lean! {.text s!"{1 + 2}"}</b>
 ```
 
 See the `Jsx.lean` and `ExprPresentation.lean` demos.


### PR DESCRIPTION
The current code has a syntax error due to a spurious `>` and a type error due to a mismatch between `String` and `Html`.