### PR TITLE
chore: set fixed `releaseRepo` & use some new Lake features

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -37,7 +37,6 @@ def buildTextFileUnlessUpToDate
     build
     clearFileHash file
   fetchTextFileTrace file
-end
 
 /-- Like `buildFileAfterDep` but interprets `file` as a text file
 so that line ending differences across platform do not impact the hash. -/
@@ -49,6 +48,7 @@ so that line ending differences across platform do not impact the hash. -/
     let depTrace := depTrace.mix (← extraDepTrace)
     let trace ← buildTextFileUnlessUpToDate file depTrace <| build depInfo
     return (file, trace)
+end
 
 /-- Target to update `package-lock.json` whenever `package.json` has changed. -/
 target widgetPackageLock : FilePath := do

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -4,6 +4,7 @@ open Lake DSL System
 package proofwidgets where
   preferReleaseBuild := true
   buildArchive? := "ProofWidgets4.tar.gz"
+  releaseRepo := "https://github.com/leanprover-community/ProofWidgets4"
 
 require batteries from git "https://github.com/leanprover-community/batteries" @ "main"
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,7 +6,7 @@ package proofwidgets where
   buildArchive? := "ProofWidgets4.tar.gz"
   releaseRepo := "https://github.com/leanprover-community/ProofWidgets4"
 
-require batteries from git "https://github.com/leanprover-community/batteries" @ "main"
+require "leanprover-community" / "batteries"
 
 def npmCmd : String :=
   if Platform.isWindows then "npm.cmd" else "npm"
@@ -14,10 +14,8 @@ def npmCmd : String :=
 def widgetDir := __dir__ / "widget"
 def buildDir := __dir__ / ".lake" / "build"
 
--- TODO: rm this and use the Lake version when it becomes available in a Lean release
-def inputTextFile' (path : FilePath) : SpawnM (BuildJob FilePath) :=
-  Job.async do (path, ·) <$> computeTrace (TextFilePath.mk path)
-
+-- TODO: Replace this section with Lake versions when there are ones
+section
 def fetchTextFileHash (file : FilePath) : JobM Hash := do
   let hashFile := FilePath.mk <| file.toString ++ ".hash"
   if (← getTrustHash) then
@@ -39,6 +37,7 @@ def buildTextFileUnlessUpToDate
     build
     clearFileHash file
   fetchTextFileTrace file
+end
 
 /-- Like `buildFileAfterDep` but interprets `file` as a text file
 so that line ending differences across platform do not impact the hash. -/
@@ -53,7 +52,7 @@ so that line ending differences across platform do not impact the hash. -/
 
 /-- Target to update `package-lock.json` whenever `package.json` has changed. -/
 target widgetPackageLock : FilePath := do
-  let packageFile ← inputTextFile' <| widgetDir / "package.json"
+  let packageFile ← inputTextFile <| widgetDir / "package.json"
   let packageLockFile := widgetDir / "package-lock.json"
   buildTextFileAfterDep packageLockFile packageFile fun _srcFile => do
     proc {
@@ -73,7 +72,7 @@ def widgetJsAllTarget (pkg : Package) (isDev : Bool) : FetchM (BuildJob (Array F
   -- See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/ProofWidgets.20v0.2E0.2E36.20and.20v0.2E0.2E39/near/446602029
   let srcs := srcs.qsort (toString · < toString ·)
   let depFiles := srcs ++ #[ widgetDir / "rollup.config.js", widgetDir / "tsconfig.json" ]
-  let deps ← liftM <| depFiles.mapM inputTextFile'
+  let deps ← liftM <| depFiles.mapM inputTextFile
   let deps := deps.push <| ← widgetPackageLock.fetch
   let deps ← BuildJob.collectArray deps
   /- `widgetJsAll` is an `extraDepTarget`,


### PR DESCRIPTION
Sets the `releaseRepo` package configuration option to ensure Lake uses the expected download URL for a ProofWidgets cloud release, rather than letting Lake attempt to detect the correct URL itself. This avoids edge cases were the detected URL is incorrect (e.g.,[this Zulip one](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/cache.20and.20proofwidgets/near/477631557)).

Also updates the lakefile to use some newer Lake features. Now it uses a Reservoir dependency for Batteries and uses Lake's `inputTextFile` rather than a local copy.