### PR TITLE
chore: cleanup deprecations

### DIFF
--- a/ProofWidgets/Component/HtmlDisplay.lean
+++ b/ProofWidgets/Component/HtmlDisplay.lean
@@ -71,18 +71,6 @@ def elabHtmlCmd : CommandElab := fun
       stx
   | stx => throwError "Unexpected syntax {stx}."
 
-/-- The `html!` tactic is deprecated and does nothing.
-If you have a use for it,
-please open an issue on https://github.com/leanprover-community/ProofWidgets4. -/
-@[deprecated "The `html!` tactic is deprecated and does nothing. If you have a use for it, \
-  please open an issue on https://github.com/leanprover-community/ProofWidgets4."
-  (since := "2024-05-15")]
-syntax (name := htmlTac) "html! " term : tactic
-
-open Tactic in
-@[tactic htmlTac]
-def elabHtmlTac : Tactic | _ => pure ()
-
 end HtmlCommand
 end ProofWidgets
 

--- a/ProofWidgets/Component/HtmlDisplay.lean
+++ b/ProofWidgets/Component/HtmlDisplay.lean
@@ -74,7 +74,9 @@ def elabHtmlCmd : CommandElab := fun
 /-- The `html!` tactic is deprecated and does nothing.
 If you have a use for it,
 please open an issue on https://github.com/leanprover-community/ProofWidgets4. -/
-@[deprecated]
+@[deprecated "The `html!` tactic is deprecated and does nothing. If you have a use for it, \
+  please open an issue on https://github.com/leanprover-community/ProofWidgets4."
+  (since := "2024-05-15")]
 syntax (name := htmlTac) "html! " term : tactic
 
 open Tactic in

--- a/ProofWidgets/Presentation/Expr.lean
+++ b/ProofWidgets/Presentation/Expr.lean
@@ -81,21 +81,6 @@ structure GetExprPresentationParams where
   name : Name
   deriving RpcEncodable
 
-@[server_rpc_method]
-def getExprPresentation : GetExprPresentationParams → RequestM (RequestTask Html)
-  | { expr := ⟨expr⟩, name } => RequestM.asTask do
-    let ci := expr.ci
-    if !exprPresenters.hasTag ci.env name then
-      throw <| RequestError.invalidParams s!"The constant '{name}' is not an Expr presenter."
-    match evalExprPresenter ci.env ci.options name with
-    | .ok p =>
-      expr.runMetaM p.present
-    | .error e =>
-      throw <| RequestError.internalError s!"Failed to evaluate Expr presenter '{name}': {e}"
-
--- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/deprecation.20warning.20from.20ProofWidgets
-attribute [deprecated] getExprPresentation
-
 structure ExprPresentationProps where
   expr : WithRpcRef ExprWithCtx
   deriving RpcEncodable


### PR DESCRIPTION
Deprecations will become stricter (requiring a `since` field and either a replacement identifier or a string explanation) after leanprover/lean4#6112.

This removes an 18-month old deprecation, and adds since field and copies the doc-string on a 6-month old deprecation (consider also just removing?)